### PR TITLE
Enable upgradation for all installed python versions

### DIFF
--- a/pipupgradeall.py
+++ b/pipupgradeall.py
@@ -1,5 +1,22 @@
 import pkg_resources, subprocess
+import os
+
+def get_all_pythons():
+    '''https://stackoverflow.com/a/52123490'''
+    output, err = subprocess.Popen(
+        ['which', '-a', 'python', 'python3','python2'], 
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).communicate()
+    return output.decode('utf8').split('\n')[:-1]
+
 def _main():
-    subprocess.run(['pip','install','-U',
-        *[dist.project_name for dist in pkg_resources.working_set]
-    ])
+    
+    all_pythons = []
+    if os.name == 'posix':
+        all_pythons = get_all_pythons()
+    if not all_pythons:
+        all_pythons = ['python']
+    for py in all_pythons:
+        subprocess.run([py, '-m', 'pip','install','-U',
+            *[dist.project_name for dist in pkg_resources.working_set]
+        ])


### PR DESCRIPTION
This PR is trying to upgrade all packages from **all versions of installed python**. This would fix an issue that, for example, "pip" for python3 is renamed as "pip3" on some OS.

> "Having a lot of python versions on the same machine is quite a common situation." by https://stackoverflow.com/a/52123490

BTW, I'm participating the [hacktoberfest](https://hacktoberfest.digitalocean.com/) event. Please consider add a label `hacktoberfest-accepted` to this PR if you admit.